### PR TITLE
Fixing issues in run-sonar.sh

### DIFF
--- a/src/main/shell/run-sonar.sh
+++ b/src/main/shell/run-sonar.sh
@@ -166,6 +166,7 @@ destinationSimulator=''; readParameter destinationSimulator 'sonar.objectivec.si
 # Your .xcworkspace/.xcodeproj filename
 workspaceFile=''; readParameter workspaceFile 'sonar.objectivec.workspace'
 projectFile=''; readParameter projectFile 'sonar.objectivec.project'
+projectVersion=''; readParameter projectVersion 'sonar.projectVersion'
 
 # Count projects
 projectCount=$(echo $projectFile | sed -n 1'p' | tr ',' '\n' | wc -l | tr -d '[[:space:]]')
@@ -209,6 +210,11 @@ if [ -z "$destinationSimulator" -o "$destinationSimulator" = " " ]; then
 	exit 1
 fi
 
+# If project version is not set in the sonar-project.properties, read it from the project bundle
+if [[ "$projectVersion" = "" ]] ; then
+    projectVersion=$(agvtool what-marketing-version -terse1)
+fi
+
 if [ "$vflag" = "on" ]; then
  	echo "Xcode workspace file is: $workspaceFile"
  	echo "Xcode project file is: $projectFile"
@@ -235,7 +241,12 @@ mkdir sonar-reports
 
 # Extracting project information needed later
 echo -n 'Extracting Xcode project information'
-buildCmd=(xcodebuild clean build -workspace $workspaceFile -scheme $appScheme)
+if [[ "$workspaceFile" != "" ]] ; then
+    buildCmdPrefix="-workspace $workspaceFile"
+else
+    buildCmdPrefix="-project $projectFile"
+fi
+buildCmd=(xcodebuild clean build $buildCmdPrefix -scheme $appScheme)
 if [[ ! -z "$destinationSimulator" ]]; then
     buildCmd+=(-destination "$destinationSimulator" -destination-timeout 360)
 fi
@@ -246,7 +257,7 @@ oclint-xcodebuild # Transform the xcodebuild.log file into a compile_command.jso
 # Unit tests and coverage
 if [ "$testScheme" = "" ]; then
 	echo 'Skipping tests as no test scheme has been provided!'
-	
+
 	# Put default xml files with no tests and no coverage...
 	echo "<?xml version='1.0' encoding='UTF-8' standalone='yes'?><testsuites name='AllTestUnits'></testsuites>" > sonar-reports/TEST-report.xml
 	echo "<?xml version='1.0' ?><!DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'><coverage><sources></sources><packages></packages></coverage>" > sonar-reports/coverage.xml
@@ -256,10 +267,10 @@ else
 
     if [ "$coverageType" = "profdata" -o "$coverageType" = "" ]; then
     	# profdata
-    	buildCmd=(xcodebuild clean build test -workspace $workspaceFile -scheme $appScheme -configuration Debug -enableCodeCoverage YES)
+    	buildCmd=(xcodebuild test $buildCmdPrefix -scheme "$testScheme" -configuration Debug -enableCodeCoverage YES)
     else
     	# Legacy coverage
-    	buildCmd=(xcodebuild clean build test -workspace $workspaceFile -scheme $appScheme -configuration Debug)
+    	buildCmd=(xcodebuild test $buildCmdPrefix -scheme "$testScheme" -configuration Debug)
     fi
 
     if [[ ! -z "$destinationSimulator" ]]; then
@@ -292,7 +303,7 @@ else
 
 		projectArray=(${projectFile//,/ })
 		firstProject=${projectArray[0]}
-        runCommand /dev/stdout $SLATHER_CMD coverage --input-format profdata $excludedCommandLineFlags --cobertura-xml --output-directory sonar-reports --scheme $appScheme $firstProject
+        runCommand /dev/stdout $SLATHER_CMD coverage --input-format profdata $excludedCommandLineFlags --cobertura-xml --output-directory sonar-reports --scheme "$testScheme" $firstProject
         mv sonar-reports/cobertura.xml sonar-reports/coverage.xml
 
 	else
@@ -420,8 +431,8 @@ fi
 
 # SonarQube
 echo -n 'Running SonarQube using SonarQube Runner'
-runCommand /dev/stdout sonar-runner
-	
+runCommand /dev/stdout sonar-runner -Dsonar.projectVersion=$projectVersion
+
 # Kill progress indicator
 stopProgress
 


### PR DESCRIPTION
1. Fixing handling of sonar.objectivec.testScheme parameter
2. Fixing handling of sonar.objectivec.project parameter
3. Making it possible to read the sonar.projectVersion parameter from the app bundle
