### PR TITLE
Test sources naming pattern update

### DIFF
--- a/src/main/java/org/sonar/plugins/objectivec/tests/SurefireParser.java
+++ b/src/main/java/org/sonar/plugins/objectivec/tests/SurefireParser.java
@@ -206,7 +206,8 @@ public class SurefireParser {
         if (!file.isFile() || !file.exists()) {
             List<File> files = ImmutableList.copyOf(fileSystem.files(fileSystem.predicates().and(
                     fileSystem.predicates().hasType(InputFile.Type.TEST),
-                    fileSystem.predicates().matchesPathPattern("**/" + fileName))));
+                    fileSystem.predicates().or(fileSystem.predicates().matchesPathPattern("**/" + fileName),
+                                               fileSystem.predicates().matchesPathPattern("**/" + fileName.replace("_", "+"))))));
 
             if (files.isEmpty()) {
                 LOG.info("Unable to locate test source file {}", fileName);


### PR DESCRIPTION
Included category naming case when searching for test source files which are not in the root.
