### PR TITLE
Do not check for gcovr when there's only Xcode 8 installed

### DIFF
--- a/src/main/shell/run-sonar.sh
+++ b/src/main/shell/run-sonar.sh
@@ -149,7 +149,6 @@ echo "Running run-sonar.sh..."
 
 # xctool, gcovr and oclint installed
 testIsInstalled xcodebuild
-testIsInstalled gcovr
 testIsInstalled oclint
 testIsInstalled oclint-xcodebuild
 


### PR DESCRIPTION
I configured a new mac yersteday which only has Xcode 8, and the run-sonar.sh script is failing when checking if gcovr is installed. I assume that it is not there if xcode 7 is not installed.
