### PR TITLE
Sonar 6 fix for Faux Pas

### DIFF
--- a/src/main/java/org/sonar/plugins/objectivec/ObjectiveCPlugin.java
+++ b/src/main/java/org/sonar/plugins/objectivec/ObjectiveCPlugin.java
@@ -77,7 +77,7 @@ public class ObjectiveCPlugin extends SonarPlugin {
     public static final String FALSE = "false";
 
     public static final String FILE_SUFFIXES_KEY = "sonar.objectivec.file.suffixes";
-    public static final String FILE_SUFFIXES_DEFVALUE = "h,m";
+    public static final String FILE_SUFFIXES_DEFVALUE = "h,m,mm";
 
     public static final String PROPERTY_PREFIX = "sonar.objectivec";
 

--- a/src/main/java/org/sonar/plugins/objectivec/violations/fauxpas/FauxPasReportParser.java
+++ b/src/main/java/org/sonar/plugins/objectivec/violations/fauxpas/FauxPasReportParser.java
@@ -89,7 +89,7 @@ public class FauxPasReportParser {
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(filePath));
             Issuable issuable = resourcePerspectives.as(Issuable.class, inputFile);
 
-            if (issuable != null) {
+            if (issuable != null && inputFile != null) {
 
                 JSONObject extent = (JSONObject)diagnosticJson.get("extent");
                 JSONObject start = (JSONObject)extent.get("start");

--- a/src/main/java/org/sonar/plugins/objectivec/violations/oclint/OCLintXMLStreamHandler.java
+++ b/src/main/java/org/sonar/plugins/objectivec/violations/oclint/OCLintXMLStreamHandler.java
@@ -104,6 +104,10 @@ final class OCLintXMLStreamHandler implements XmlStreamHandler {
     }
 
     private boolean fileExists(InputFile file) {
+        if (file == null) {
+            return false;
+        }
+
         return context.getResource(file) != null;
     }
 


### PR DESCRIPTION
Issuable is created even if the inputFile is null
Check if inputFile is null before continuing execution

Fixes issue #19 
This happens for example if we have a file with a whitespace in the path. There should be a better way to handle these files though.
In the previous version they were ignored as well.