### PR TITLE
Add sonar plugin api to fix classnotfound CodeColorizerFormat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,11 @@
             <artifactId>sonar-surefire-plugin</artifactId>
             <version>2.7</version>
         </dependency>
+        <dependency>
+           <groupId>org.sonarsource.sonarqube</groupId>
+           <artifactId>sonar-plugin-api</artifactId>
+           <version>6.3</version>
+       </dependency>
 
     </dependencies>
-
 </project>


### PR DESCRIPTION
Fix exception when try to deploy SonarQube

(java.lang.ClassNotFoundException: org.sonar.api.web.CodeColorizerFormat)