### PR TITLE
oclint-0.13-support: integrate latest oclint 0.13 rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
-  - openjdk6

--- a/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
+++ b/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
@@ -5,10 +5,6 @@
   <rules>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
-      <key>use early exits and continue</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
       <key>avoid branching statement as last in loop</key>
     </rule>
     <rule>
@@ -46,10 +42,6 @@
     <rule>
       <repositoryKey>OCLint</repositoryKey>
       <key>dead code</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>default label not last in switch statement</key>
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
@@ -145,6 +137,10 @@
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
+      <key>must override hash with isEqual</key>
+    </rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
       <key>high ncss method</key>
     </rule>
     <rule>
@@ -158,22 +154,6 @@
     <rule>
       <repositoryKey>OCLint</repositoryKey>
       <key>high npath complexity</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>replace with boxed expression</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>replace with container literal</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>replace with number literal</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>replace with object subscripting</key>
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
@@ -206,10 +186,6 @@
     <rule>
       <repositoryKey>OCLint</repositoryKey>
       <key>switch statements don't need default when fully covered</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
-      <key>switch statements should have default</key>
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
@@ -253,10 +229,6 @@
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
-      <key>covered switch statements dont need default</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
       <key>class</key>
     </rule>
     <rule>
@@ -281,10 +253,6 @@
     </rule>
     <rule>
       <repositoryKey>OCLint</repositoryKey>
-      <key>use object subscripting</key>
-    </rule>
-    <rule>
-      <repositoryKey>OCLint</repositoryKey>
       <key>use boxed expression</key>
     </rule>
     <rule>
@@ -295,21 +263,25 @@
       <repositoryKey>OCLint</repositoryKey>
       <key>use number literal</key>
     </rule>
-	<rule>
-		<repositoryKey>OCLint</repositoryKey>
-		<key>missing hash method</key>
-	</rule>
-	<rule>
-		<repositoryKey>OCLint</repositoryKey>
-		<key>missing call to base method</key>
-	</rule>
-	<rule>
-		<repositoryKey>OCLint</repositoryKey>
-		<key>calling prohibited method</key>
-	</rule>
-	<rule>
-		<repositoryKey>OCLint</repositoryKey>
-		<key>missing abstract method implementation</key>
-	</rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
+      <key>use object subscripting</key>
+    </rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
+      <key>missing hash method</key>
+    </rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
+      <key>missing call to base method</key>
+    </rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
+      <key>calling prohibited method</key>
+    </rule>
+    <rule>
+      <repositoryKey>OCLint</repositoryKey>
+      <key>missing abstract method implementation</key>
+    </rule>
   </rules>
 </profile>

--- a/src/main/resources/org/sonar/plugins/oclint/rules.txt
+++ b/src/main/resources/org/sonar/plugins/oclint/rules.txt
@@ -470,7 +470,7 @@ Category: OCLint
 unnecessary default statement in covered switch statement
 ----------
 
-Summary: When a switch statement covers all possible cases, a default label is not needed and should be removed. If the switch is not fully covered, the SwitchStatementsShouldHaveDefault rule will report.
+Summary: Name: unnecessary default statement in covered switch statement
 
 Severity: 2
 Category: OCLint
@@ -478,7 +478,7 @@ Category: OCLint
 ill-placed default label in switch statement
 ----------
 
-Summary: It is very confusing when default label is not the last label in a switch statement.
+Summary: Name: ill-placed default label in switch statement
 
 Severity: 2
 Category: OCLint
@@ -486,7 +486,7 @@ Category: OCLint
 prefer early exits and continue
 ----------
 
-Summary: Early exits can reduce the indentation of a block of code, so that reader do not have to remember all the previous decisions, therefore, makes it easier to understand the code.
+Summary: Name: prefer early exits and continue
 
 Severity: 2
 Category: OCLint
@@ -494,7 +494,7 @@ Category: OCLint
 missing default in switch statements
 ----------
 
-Summary: Switch statements should have a default statement.
+Summary: Name: missing default in switch statements
 
 Severity: 2
 Category: OCLint
@@ -502,7 +502,7 @@ Category: OCLint
 use boxed expression
 ----------
 
-Summary: This rule locates the places that can be migrated to the new Objective-C literals with boxed expressions.
+Summary: Name: use boxed expression
 
 Severity: 1
 Category: OCLint
@@ -510,7 +510,7 @@ Category: OCLint
 use container literal
 ----------
 
-Summary: This rule locates the places that can be migrated to the new Objective-C literals with container literals.
+Summary: Name: use container literal
 
 Severity: 1
 Category: OCLint
@@ -518,7 +518,7 @@ Category: OCLint
 use number literal
 ----------
 
-Summary: This rule locates the places that can be migrated to the new Objective-C literals with number literals.
+Summary: Name: use number literal
 
 Severity: 1
 Category: OCLint
@@ -526,7 +526,7 @@ Category: OCLint
 use object subscripting
 ----------
 
-Summary: Name: use object subscripting
+Summary: 
 
 Severity: 1
 Category: OCLint
@@ -562,5 +562,4 @@ Summary: Name: missing abstract method implementation
 
 Severity: 1
 Category: OCLint
-
 


### PR DESCRIPTION
This fixes #45 and #46 by supporting new rules from oclint 0.13, see http://docs.oclint.org/en/stable/rules