### PR TITLE
Support for Sonar 6.5. Added missing dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,12 @@
             <artifactId>sonar-surefire-plugin</artifactId>
             <version>2.7</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <version>6.3</version>
+        </dependency>
+        
     </dependencies>
 
 </project>


### PR DESCRIPTION
Making the same change that was done on the swift plugin. https://github.com/Backelite/sonar-swift/pull/94

Note: There is much more that should be updated, but this is the minimum required to get the plugin to work with Sonar 6.5