### PR TITLE
PersistanceMode dropped by sonarqube 7.0

### DIFF
--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -156,7 +156,7 @@ public class LizardReportParser {
         list.add(new Measure(CoreMetrics.FILE_COMPLEXITY, fileComplexity));
         RangeDistributionBuilder complexityDistribution = new RangeDistributionBuilder(CoreMetrics.FILE_COMPLEXITY_DISTRIBUTION, FILES_DISTRIB_BOTTOM_LIMITS);
         complexityDistribution.add(fileComplexity);
-        list.add(complexityDistribution.build().setPersistenceMode(PersistenceMode.MEMORY));
+        list.add(complexityDistribution.build());
         return list;
     }
 
@@ -224,7 +224,7 @@ public class LizardReportParser {
         List<Measure> list = new ArrayList<Measure>();
         list.add(new Measure(CoreMetrics.FUNCTION_COMPLEXITY, complexMean));
         list.add(new Measure(CoreMetrics.COMPLEXITY_IN_FUNCTIONS).setIntValue(complexityInFunctions));
-        list.add(builder.build().setPersistenceMode(PersistenceMode.MEMORY));
+        list.add(builder.build());
         return list;
     }
 


### PR DESCRIPTION
PersistanceMode class was removed from Sonarqube, this commit solves the following error.


ERROR: Error during SonarQube Scanner execution
java.lang.NoClassDefFoundError: org/sonar/api/measures/PersistenceMode
	at org.sonar.plugins.objectivec.complexity.LizardReportParser.buildMeasureList(LizardReportParser.java:159)
	at org.sonar.plugins.objectivec.complexity.LizardReportParser.addComplexityFileMeasures(LizardReportParser.java:140)
	at org.sonar.plugins.objectivec.complexity.LizardReportParser.parseFile(LizardReportParser.java:109)
	at org.sonar.plugins.objectivec.complexity.LizardReportParser.parseReport(LizardReportParser.java:77)
	at org.sonar.plugins.objectivec.complexity.LizardSensor.parseReportsIn(LizardSensor.java:88)
	at org.sonar.plugins.objectivec.complexity.LizardSensor.analyse(LizardSensor.java:73)
