### PR TITLE
Skip Deprecated complexity metrics SQv6.7+

### DIFF
--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -39,6 +39,8 @@ import java.util.Map;
 public class LizardMeasurePersistor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardMeasurePersistor.class);
+    private static final String SKIP_FILE_COMPLEXITY = "file_complexity";
+    private static final String SKIP_FUNC_COMPLEXITY = "function_complexity";
 
     private final Project project;
     private final SensorContext sensorContext;
@@ -73,6 +75,12 @@ public class LizardMeasurePersistor {
 
             if (resource != null) {
                 for (Measure measure : entry.getValue()) {
+                    if (measure.getMetric().getKey().equals(SKIP_FILE_COMPLEXITY) || measure.getMetric().getKey().equals(SKIP_FUNC_COMPLEXITY) ) {
+                        LOGGER.info("SKIPPING METRIC: " + String.valueOf(measure.getMetric().getKey()));
+                        continue;
+                    }
+                    LOGGER.info("USING METRIC: " + String.valueOf(measure.getMetric().getKey()));
+
                     try {
                         LOGGER.debug("Save measure {} for file {}", measure.getMetric().getName(), file);
                         sensorContext.saveMeasure(resource, measure);


### PR DESCRIPTION
This is a workaround for deprecated File Complexity/ Function Complexity which generated by lizard. Sonarqube makes these deprecated from v 6.7.

Issue reference:
https://github.com/Backelite/sonar-objective-c/issues/54