### PR TITLE
Improve implementation for parsing Lizard reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <logback.version>1.0.13</logback.version>
         <mockito.version>1.9.0</mockito.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <sonar.version>7.0</sonar.version>
+        <sonar.version>5.6</sonar.version>
         <sonar-orchestrator.version>3.13</sonar-orchestrator.version>
         <sonarlint.version>2.5.0.36</sonarlint.version>
         <sslr.version>1.22</sslr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <logback.version>1.0.13</logback.version>
         <mockito.version>1.9.0</mockito.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <sonar.version>5.6</sonar.version>
+        <sonar.version>7.0</sonar.version>
         <sonar-orchestrator.version>3.13</sonar-orchestrator.version>
         <sonarlint.version>2.5.0.36</sonarlint.version>
         <sslr.version>1.22</sslr.version>

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasure.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasure.java
@@ -21,7 +21,7 @@ import org.sonar.api.batch.measure.Metric;
 
 import java.io.Serializable;
 
-class LizardMeasure<T extends Serializable> {
+final class LizardMeasure<T extends Serializable> {
     private final Metric<T> metric;
     private final T value;
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasure.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasure.java
@@ -1,0 +1,44 @@
+/**
+ * backelite-sonar-objective-c-plugin - Enables analysis of Objective-C projects into SonarQube.
+ * Copyright © 2012 OCTO Technology, Backelite (${email})
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sonar.plugins.objectivec.complexity;
+
+import org.sonar.api.batch.measure.Metric;
+
+import java.io.Serializable;
+
+class LizardMeasure<T extends Serializable> {
+    private final Metric<T> metric;
+    private final T value;
+
+    private LizardMeasure(Metric<T> metric, T value) {
+        this.metric = metric;
+        this.value = value;
+    }
+
+    static <T extends Serializable> LizardMeasure of(Metric<T> metric, T value) {
+        return new LizardMeasure<>(metric, value);
+    }
+
+    public Metric<T> getMetric() {
+        return metric;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -24,6 +24,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.measure.Metric;
 import org.sonar.api.batch.sensor.SensorContext;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
@@ -51,12 +52,7 @@ public class LizardMeasurePersistor {
      *
      * @param measures Map containing as key the name of the file and as value a list containing the measures for that file
      */
-    public <T extends Serializable> void saveMeasures(final Map<String, List<LizardMeasure<T>>> measures) {
-
-        if (measures == null) {
-            return;
-        }
-
+    public <T extends Serializable> void saveMeasures(@Nonnull final Map<String, List<LizardMeasure<T>>> measures) {
         for (Map.Entry<String, List<LizardMeasure<T>>> entry : measures.entrySet()) {
             File file = new File(fileSystem.baseDir(), entry.getKey());
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(file.getAbsolutePath()));

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -23,7 +23,6 @@ import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.measures.Measure;
-import org.sonar.api.resources.Project;
 import org.sonar.api.resources.Resource;
 
 import java.io.File;
@@ -40,12 +39,10 @@ public class LizardMeasurePersistor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardMeasurePersistor.class);
 
-    private final Project project;
     private final SensorContext sensorContext;
     private final FileSystem fileSystem;
 
-    public LizardMeasurePersistor(final Project project, final SensorContext sensorContext, final FileSystem fileSystem) {
-        this.project = project;
+    public LizardMeasurePersistor(final SensorContext sensorContext, final FileSystem fileSystem) {
         this.sensorContext = sensorContext;
         this.fileSystem = fileSystem;
     }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -42,7 +42,7 @@ public class LizardMeasurePersistor {
     private final SensorContext sensorContext;
     private final FileSystem fileSystem;
 
-    public LizardMeasurePersistor(final SensorContext sensorContext, final FileSystem fileSystem) {
+    LizardMeasurePersistor(final SensorContext sensorContext, final FileSystem fileSystem) {
         this.sensorContext = sensorContext;
         this.fileSystem = fileSystem;
     }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -62,9 +62,7 @@ final class LizardMeasurePersistor {
                 continue;
             }
 
-            for (LizardMeasure<T> measure : entry.getValue()) {
-                saveMeasure(inputFile, measure);
-            }
+            entry.getValue().forEach(measure -> saveMeasure(inputFile, measure));
         }
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -19,10 +19,10 @@ package org.sonar.plugins.objectivec.complexity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.measure.Metric;
+import org.sonar.api.batch.sensor.SensorContext;
 
 import java.io.File;
 import java.io.Serializable;

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -45,7 +45,7 @@ final class LizardMeasurePersistor {
     private final SensorContext sensorContext;
     private final FileSystem fileSystem;
 
-    LizardMeasurePersistor(final SensorContext sensorContext, final FileSystem fileSystem) {
+    LizardMeasurePersistor(@Nonnull final SensorContext sensorContext, @Nonnull final FileSystem fileSystem) {
         this.sensorContext = sensorContext;
         this.fileSystem = fileSystem;
     }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * @author Andres Gil Herrera
  * @since 28/05/15.
  */
-class LizardMeasurePersistor {
+final class LizardMeasurePersistor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardMeasurePersistor.class);
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * @author Andres Gil Herrera
  * @since 28/05/15.
  */
-public class LizardMeasurePersistor {
+class LizardMeasurePersistor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardMeasurePersistor.class);
 
@@ -52,7 +52,7 @@ public class LizardMeasurePersistor {
      *
      * @param measures Map containing as key the name of the file and as value a list containing the measures for that file
      */
-    public <T extends Serializable> void saveMeasures(@Nonnull final Map<String, List<LizardMeasure<T>>> measures) {
+    <T extends Serializable> void saveMeasures(@Nonnull final Map<String, List<LizardMeasure<T>>> measures) {
         for (Map.Entry<String, List<LizardMeasure<T>>> entry : measures.entrySet()) {
             File file = new File(fileSystem.baseDir(), entry.getKey());
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(file.getAbsolutePath()));

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -78,14 +78,14 @@ final class LizardMeasurePersistor {
         Metric<T> metric = measure.getMetric();
 
         try {
-            LOGGER.debug("Save measure {} for file {}", metric.key(), inputFile.filename());
+            LOGGER.debug("Save measure {} for file {}", metric.key(), inputFile.relativePath());
             sensorContext.<T>newMeasure()
                     .on(inputFile)
                     .forMetric(metric)
                     .withValue(measure.getValue())
                     .save();
         } catch (Exception e) {
-            LOGGER.error(" Exception -> {} -> {}", inputFile.filename(), metric.key(), e);
+            LOGGER.error(" Exception -> {} -> {}", inputFile.relativePath(), metric.key(), e);
         }
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardMeasurePersistor.java
@@ -22,10 +22,10 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.measures.Measure;
-import org.sonar.api.resources.Resource;
+import org.sonar.api.batch.measure.Metric;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -51,13 +51,13 @@ public class LizardMeasurePersistor {
      *
      * @param measures Map containing as key the name of the file and as value a list containing the measures for that file
      */
-    public void saveMeasures(final Map<String, List<Measure>> measures) {
+    public <T extends Serializable> void saveMeasures(final Map<String, List<LizardMeasure<T>>> measures) {
 
         if (measures == null) {
             return;
         }
 
-        for (Map.Entry<String, List<Measure>> entry : measures.entrySet()) {
+        for (Map.Entry<String, List<LizardMeasure<T>>> entry : measures.entrySet()) {
             File file = new File(fileSystem.baseDir(), entry.getKey());
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(file.getAbsolutePath()));
 
@@ -66,18 +66,24 @@ public class LizardMeasurePersistor {
                 continue;
             }
 
-            Resource resource = sensorContext.getResource(inputFile);
-
-            if (resource != null) {
-                for (Measure measure : entry.getValue()) {
-                    try {
-                        LOGGER.debug("Save measure {} for file {}", measure.getMetric().getName(), file);
-                        sensorContext.saveMeasure(resource, measure);
-                    } catch (Exception e) {
-                        LOGGER.error(" Exception -> {} -> {}", entry.getKey(), measure.getMetric().getName(), e);
-                    }
-                }
+            for (LizardMeasure<T> measure : entry.getValue()) {
+                saveMeasure(inputFile, measure);
             }
+        }
+    }
+
+    private <T extends Serializable> void saveMeasure(InputFile inputFile, LizardMeasure<T> measure) {
+        Metric<T> metric = measure.getMetric();
+
+        try {
+            LOGGER.debug("Save measure {} for file {}", metric.key(), inputFile.filename());
+            sensorContext.<T>newMeasure()
+                    .on(inputFile)
+                    .forMetric(metric)
+                    .withValue(measure.getValue())
+                    .save();
+        } catch (Exception e) {
+            LOGGER.error(" Exception -> {} -> {}", inputFile.filename(), metric.key(), e);
         }
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -156,7 +156,7 @@ public class LizardReportParser {
         list.add(new Measure(CoreMetrics.FILE_COMPLEXITY, fileComplexity));
         RangeDistributionBuilder complexityDistribution = new RangeDistributionBuilder(CoreMetrics.FILE_COMPLEXITY_DISTRIBUTION, FILES_DISTRIB_BOTTOM_LIMITS);
         complexityDistribution.add(fileComplexity);
-        list.add(complexityDistribution.build().setPersistenceMode(PersistenceMode.MEMORY));
+        list.add(complexityDistribution.build());
         return list;
     }
 
@@ -224,7 +224,7 @@ public class LizardReportParser {
         List<Measure> list = new ArrayList<Measure>();
         list.add(new Measure(CoreMetrics.FUNCTION_COMPLEXITY, complexMean));
         list.add(new Measure(CoreMetrics.COMPLEXITY_IN_FUNCTIONS).setIntValue(complexityInFunctions));
-        list.add(builder.build().setPersistenceMode(PersistenceMode.MEMORY));
+        list.add(builder.build());
         return list;
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -94,13 +94,15 @@ public class LizardReportParser {
 
         for (int i = 0; i < nodeList.getLength(); i++) {
             Node node = nodeList.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
 
-            if (node.getNodeType() == Node.ELEMENT_NODE) {
-                Element element = (Element) node;
-                if (element.getAttribute(MEASURE_TYPE).equalsIgnoreCase(FILE_MEASURE)) {
-                    NodeList itemList = element.getElementsByTagName(MEASURE_ITEM);
-                    addComplexityFileMeasures(itemList, reportMeasures);
-                }
+            Element element = (Element) node;
+
+            if (element.getAttribute(MEASURE_TYPE).equalsIgnoreCase(FILE_MEASURE)) {
+                NodeList itemList = element.getElementsByTagName(MEASURE_ITEM);
+                addComplexityFileMeasures(itemList, reportMeasures);
             }
         }
 
@@ -116,14 +118,15 @@ public class LizardReportParser {
     private <T extends Serializable> void addComplexityFileMeasures(NodeList itemList, Map<String, List<LizardMeasure<T>>> reportMeasures) {
         for (int i = 0; i < itemList.getLength(); i++) {
             Node item = itemList.item(i);
-
-            if (item.getNodeType() == Node.ELEMENT_NODE) {
-                Element itemElement = (Element) item;
-                String fileName = itemElement.getAttribute(NAME);
-                NodeList values = itemElement.getElementsByTagName(VALUE);
-
-                reportMeasures.put(fileName, buildMeasuresFromValues(values));
+            if (item.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
             }
+
+            Element itemElement = (Element) item;
+            String fileName = itemElement.getAttribute(NAME);
+            NodeList values = itemElement.getElementsByTagName(VALUE);
+
+            reportMeasures.put(fileName, buildMeasuresFromValues(values));
         }
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -42,7 +42,7 @@ import java.util.*;
  * @author Andres Gil Herrera
  * @since 28/05/15
  */
-public class LizardReportParser {
+class LizardReportParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardReportParser.class);
 
@@ -61,7 +61,7 @@ public class LizardReportParser {
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
     @Nonnull
-    public <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReport(final File xmlFile) {
+    <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReport(final File xmlFile) {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
         try {

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -42,7 +42,7 @@ import java.util.*;
  * @author Andres Gil Herrera
  * @since 28/05/15
  */
-class LizardReportParser {
+final class LizardReportParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardReportParser.class);
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nonnull;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -33,10 +34,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This class parses xml Reports form the tool Lizard in order to extract this measures:
@@ -64,14 +62,15 @@ public class LizardReportParser {
      * @param xmlFile lizard xml report
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
+    @Nonnull
     public <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReport(final File xmlFile) {
-        Map<String, List<LizardMeasure<T>>> result = null;
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
         try {
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(xmlFile);
-            result = parseFile(document);
+
+            return parseFile(document);
         } catch (final FileNotFoundException e){
             LOGGER.error("Lizard Report not found {}", xmlFile, e);
         } catch (final IOException e) {
@@ -82,7 +81,7 @@ public class LizardReportParser {
             LOGGER.error("Error processing file named {}", xmlFile, e);
         }
 
-        return result;
+        return Collections.emptyMap();
     }
 
     /**

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -61,7 +61,7 @@ final class LizardReportParser {
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
     @Nonnull
-    <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReport(final File xmlFile) {
+    <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReport(@Nonnull final File xmlFile) {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
         try {
@@ -85,7 +85,8 @@ final class LizardReportParser {
      * @param document Document object representing the lizard report
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
-    private <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseFile(Document document) {
+    @Nonnull
+    private <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseFile(@Nonnull Document document) {
         final Map<String, List<LizardMeasure<T>>> reportMeasures = new HashMap<>();
 
         NodeList nodeList = document.getElementsByTagName(MEASURE);
@@ -107,7 +108,10 @@ final class LizardReportParser {
         return reportMeasures;
     }
 
-    private <T extends Serializable> void addComplexityFileMeasures(NodeList itemList, Map<String, List<LizardMeasure<T>>> reportMeasures) {
+    private <T extends Serializable> void addComplexityFileMeasures(
+            @Nonnull NodeList itemList,
+            @Nonnull Map<String, List<LizardMeasure<T>>> reportMeasures
+    ) {
         for (int i = 0; i < itemList.getLength(); i++) {
             Node item = itemList.item(i);
             if (item.getNodeType() != Node.ELEMENT_NODE) {
@@ -122,7 +126,8 @@ final class LizardReportParser {
         }
     }
 
-    private <T extends Serializable> List<LizardMeasure<T>> buildMeasuresFromValues(NodeList values) {
+    @Nonnull
+    private <T extends Serializable> List<LizardMeasure<T>> buildMeasuresFromValues(@Nonnull NodeList values) {
         int complexity = Integer.parseInt(values.item(CYCLOMATIC_COMPLEXITY_INDEX).getTextContent());
         int numberOfFunctions = Integer.parseInt(values.item(FUNCTIONS_INDEX).getTextContent());
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 /**
  * This class parses xml Reports form the tool Lizard in order to extract this measures:
- *      COMPLEXITY, FUNCTIONS, FUNCTION_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION,
+ *      COMPLEXITY, FUNCTIONS, FUNCTION_COMPLEXITY_DISTRIBUTION,
  *      FILE_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION
  *
  * @author Andres Gil Herrera
@@ -181,7 +181,7 @@ public class LizardReportParser {
      *
      * @param reportMeasures map to save the measures for the different files
      * @param functions list of ObjCFunction to extract the information needed to create
-     *                  FUNCTION_COMPLEXITY_DISTRIBUTION, FUNCTION_COMPLEXITY
+     *                  FUNCTION_COMPLEXITY_DISTRIBUTION
      */
     private void addComplexityFunctionMeasures(Map<String, List<Measure>> reportMeasures, List<ObjCFunction> functions){
         for (Map.Entry<String, List<Measure>> entry : reportMeasures.entrySet()) {
@@ -197,29 +197,18 @@ public class LizardReportParser {
             }
 
             if (count != 0) {
-                double complex = 0;
-                for (Measure m : entry.getValue()){
-                    if (m.getMetric().getKey().equalsIgnoreCase(CoreMetrics.FILE_COMPLEXITY.getKey())){
-                        complex = m.getValue();
-                        break;
-                    }
-                }
-
-                double complexMean = complex/(double)count;
-                entry.getValue().addAll(buildFunctionMeasuresList(complexMean, complexityDistribution));
+                entry.getValue().addAll(buildFunctionMeasuresList(complexityDistribution));
             }
         }
     }
 
     /**
      *
-     * @param complexMean average complexity per function in a file
      * @param builder Builder ready to build FUNCTION_COMPLEXITY_DISTRIBUTION
-     * @return list of Measures containing FUNCTION_COMPLEXITY_DISTRIBUTION and FUNCTION_COMPLEXITY
+     * @return list of Measures containing FUNCTION_COMPLEXITY_DISTRIBUTION
      */
-    public List<Measure> buildFunctionMeasuresList(double complexMean, RangeDistributionBuilder builder){
+    public List<Measure> buildFunctionMeasuresList(RangeDistributionBuilder builder){
         List<Measure> list = new ArrayList<Measure>();
-        list.add(new Measure(CoreMetrics.FUNCTION_COMPLEXITY, complexMean));
         list.add(builder.build());
         return list;
     }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -50,7 +50,6 @@ public class LizardReportParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardReportParser.class);
 
     private final Number[] FUNCTIONS_DISTRIB_BOTTOM_LIMITS = {1, 2, 4, 6, 8, 10, 12, 20, 30};
-    private final Number[] FILES_DISTRIB_BOTTOM_LIMITS = {0, 5, 10, 20, 30, 60, 90};
 
     private static final String MEASURE = "measure";
     private static final String MEASURE_TYPE = "type";
@@ -134,10 +133,9 @@ public class LizardReportParser {
                 String fileName = itemElement.getAttribute(NAME);
                 NodeList values = itemElement.getElementsByTagName(VALUE);
                 int complexity = Integer.parseInt(values.item(CYCLOMATIC_COMPLEXITY_INDEX).getTextContent());
-                double fileComplexity = Double.parseDouble(values.item(CYCLOMATIC_COMPLEXITY_INDEX).getTextContent());
                 int numberOfFunctions =  Integer.parseInt(values.item(FUNCTIONS_INDEX).getTextContent());
 
-                reportMeasures.put(fileName, buildMeasureList(complexity, fileComplexity, numberOfFunctions));
+                reportMeasures.put(fileName, buildMeasureList(complexity, numberOfFunctions));
             }
         }
     }
@@ -145,18 +143,14 @@ public class LizardReportParser {
     /**
      *
      * @param complexity overall complexity of the file
-     * @param fileComplexity file complexity
      * @param numberOfFunctions number of functions in the file
-     * @return returns a list of tree measures COMPLEXITY, FUNCTIONS, FILE_COMPLEXITY with the values specified
+     * @return returns a list of tree measures COMPLEXITY, FUNCTIONS with the values specified
      */
-    private List<Measure> buildMeasureList(int complexity, double fileComplexity, int numberOfFunctions){
+    private List<Measure> buildMeasureList(int complexity, int numberOfFunctions){
         List<Measure> list = new ArrayList<Measure>();
         list.add(new Measure(CoreMetrics.COMPLEXITY).setIntValue(complexity));
         list.add(new Measure(CoreMetrics.FUNCTIONS).setIntValue(numberOfFunctions));
-        list.add(new Measure(CoreMetrics.FILE_COMPLEXITY, fileComplexity));
-        RangeDistributionBuilder complexityDistribution = new RangeDistributionBuilder(CoreMetrics.FILE_COMPLEXITY_DISTRIBUTION, FILES_DISTRIB_BOTTOM_LIMITS);
-        complexityDistribution.add(fileComplexity);
-        list.add(complexityDistribution.build());
+
         return list;
     }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -73,11 +73,9 @@ public class LizardReportParser {
             return parseFile(document);
         } catch (final FileNotFoundException e){
             LOGGER.error("Lizard Report not found {}", xmlFile, e);
-        } catch (final IOException e) {
-            LOGGER.error("Error processing file named {}", xmlFile, e);
         } catch (final ParserConfigurationException e) {
             LOGGER.error("Error parsing file named {}", xmlFile, e);
-        } catch (final SAXException e) {
+        } catch (final IOException | SAXException e) {
             LOGGER.error("Error processing file named {}", xmlFile, e);
         }
 

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /**
  * This class parses xml Reports form the tool Lizard in order to extract this measures:
  *      COMPLEXITY, FUNCTIONS, FUNCTION_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION,
- *      FILE_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION, COMPLEXITY_IN_FUNCTIONS
+ *      FILE_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION
  *
  * @author Andres Gil Herrera
  * @since 28/05/15
@@ -181,20 +181,18 @@ public class LizardReportParser {
      *
      * @param reportMeasures map to save the measures for the different files
      * @param functions list of ObjCFunction to extract the information needed to create
-     *                  FUNCTION_COMPLEXITY_DISTRIBUTION, FUNCTION_COMPLEXITY, COMPLEXITY_IN_FUNCTIONS
+     *                  FUNCTION_COMPLEXITY_DISTRIBUTION, FUNCTION_COMPLEXITY
      */
     private void addComplexityFunctionMeasures(Map<String, List<Measure>> reportMeasures, List<ObjCFunction> functions){
         for (Map.Entry<String, List<Measure>> entry : reportMeasures.entrySet()) {
 
             RangeDistributionBuilder complexityDistribution = new RangeDistributionBuilder(CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION, FUNCTIONS_DISTRIB_BOTTOM_LIMITS);
             int count = 0;
-            int complexityInFunctions = 0;
 
             for (ObjCFunction func : functions) {
                 if (func.getName().contains(entry.getKey())) {
                     complexityDistribution.add(func.getCyclomaticComplexity());
                     count++;
-                    complexityInFunctions += func.getCyclomaticComplexity();
                 }
             }
 
@@ -208,7 +206,7 @@ public class LizardReportParser {
                 }
 
                 double complexMean = complex/(double)count;
-                entry.getValue().addAll(buildFunctionMeasuresList(complexMean, complexityInFunctions, complexityDistribution));
+                entry.getValue().addAll(buildFunctionMeasuresList(complexMean, complexityDistribution));
             }
         }
     }
@@ -216,14 +214,12 @@ public class LizardReportParser {
     /**
      *
      * @param complexMean average complexity per function in a file
-     * @param complexityInFunctions Entire complexity in functions
      * @param builder Builder ready to build FUNCTION_COMPLEXITY_DISTRIBUTION
-     * @return list of Measures containing FUNCTION_COMPLEXITY_DISTRIBUTION, FUNCTION_COMPLEXITY and COMPLEXITY_IN_FUNCTIONS
+     * @return list of Measures containing FUNCTION_COMPLEXITY_DISTRIBUTION and FUNCTION_COMPLEXITY
      */
-    public List<Measure> buildFunctionMeasuresList(double complexMean, int complexityInFunctions, RangeDistributionBuilder builder){
+    public List<Measure> buildFunctionMeasuresList(double complexMean, RangeDistributionBuilder builder){
         List<Measure> list = new ArrayList<Measure>();
         list.add(new Measure(CoreMetrics.FUNCTION_COMPLEXITY, complexMean));
-        list.add(new Measure(CoreMetrics.COMPLEXITY_IN_FUNCTIONS).setIntValue(complexityInFunctions));
         list.add(builder.build());
         return list;
     }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -121,18 +121,23 @@ public class LizardReportParser {
                 Element itemElement = (Element) item;
                 String fileName = itemElement.getAttribute(NAME);
                 NodeList values = itemElement.getElementsByTagName(VALUE);
-                int complexity = Integer.parseInt(values.item(CYCLOMATIC_COMPLEXITY_INDEX).getTextContent());
-                int numberOfFunctions =  Integer.parseInt(values.item(FUNCTIONS_INDEX).getTextContent());
 
-                // TODO: Proper handling of unchecked assignment.
-                List<LizardMeasure<T>> list = new ArrayList<>();
-                //noinspection unchecked
-                list.add(LizardMeasure.of(CoreMetrics.COMPLEXITY, complexity));
-                //noinspection unchecked
-                list.add(LizardMeasure.of(CoreMetrics.FUNCTIONS, numberOfFunctions));
-
-                reportMeasures.put(fileName, list);
+                reportMeasures.put(fileName, buildMeasuresFromValues(values));
             }
         }
+    }
+
+    private <T extends Serializable> List<LizardMeasure<T>> buildMeasuresFromValues(NodeList values) {
+        int complexity = Integer.parseInt(values.item(CYCLOMATIC_COMPLEXITY_INDEX).getTextContent());
+        int numberOfFunctions = Integer.parseInt(values.item(FUNCTIONS_INDEX).getTextContent());
+
+        // TODO: Proper handling of unchecked assignment.
+        List<LizardMeasure<T>> measures = new ArrayList<>();
+        //noinspection unchecked
+        measures.add(LizardMeasure.of(CoreMetrics.COMPLEXITY, complexity));
+        //noinspection unchecked
+        measures.add(LizardMeasure.of(CoreMetrics.FUNCTIONS, numberOfFunctions));
+
+        return measures;
     }
 }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardReportParser.java
@@ -37,9 +37,7 @@ import java.io.Serializable;
 import java.util.*;
 
 /**
- * This class parses xml Reports form the tool Lizard in order to extract this measures:
- *      COMPLEXITY, FUNCTIONS, FUNCTION_COMPLEXITY_DISTRIBUTION,
- *      FILE_COMPLEXITY, FUNCTION_COMPLEXITY_DISTRIBUTION
+ * This class parses xml Reports form the tool Lizard in order to extract this measures: COMPLEXITY, FUNCTIONS
  *
  * @author Andres Gil Herrera
  * @since 28/05/15
@@ -109,12 +107,6 @@ public class LizardReportParser {
         return reportMeasures;
     }
 
-    /**
-     * This method extracts the values for COMPLEXITY, FUNCTIONS, FILE_COMPLEXITY
-     *
-     * @param itemList list of all items from a <measure type=file>
-     * @param reportMeasures map to save the measures for each file
-     */
     private <T extends Serializable> void addComplexityFileMeasures(NodeList itemList, Map<String, List<LizardMeasure<T>>> reportMeasures) {
         for (int i = 0; i < itemList.getLength(); i++) {
             Node item = itemList.item(i);

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -19,9 +19,9 @@ package org.sonar.plugins.objectivec.complexity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.Settings;
 import org.sonar.plugins.objectivec.ObjectiveCPlugin;
@@ -100,7 +100,7 @@ public class LizardSensor implements Sensor {
     }
 
     @Override
-    public void execute(@Nonnull org.sonar.api.batch.sensor.SensorContext context) {
-        analyse((SensorContext) context);
+    public void execute(@Nonnull SensorContext context) {
+        analyse(context);
     }
 }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -24,12 +24,12 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.Settings;
-import org.sonar.api.measures.Measure;
 import org.sonar.plugins.objectivec.ObjectiveCPlugin;
 import org.sonar.plugins.objectivec.core.ObjectiveC;
 
 import javax.annotation.Nonnull;
 import java.io.File;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +63,7 @@ public class LizardSensor implements Sensor {
      */
     private void analyse(SensorContext sensorContext) {
         final String projectBaseDir = fileSystem.baseDir().getPath();
-        Map<String, List<Measure>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
+        Map<String, List<LizardMeasure<Integer>>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
         LOGGER.info("Saving results of complexity analysis");
         new LizardMeasurePersistor(sensorContext, fileSystem).saveMeasures(measures);
     }
@@ -74,7 +74,7 @@ public class LizardSensor implements Sensor {
      * @param parser LizardReportParser to parse the report
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
-    private Map<String, List<Measure>> parseReportsIn(final String baseDir, LizardReportParser parser) {
+    private <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReportsIn(final String baseDir, LizardReportParser parser) {
         final StringBuilder reportFileName = new StringBuilder(baseDir);
         reportFileName.append("/").append(reportPath());
         LOGGER.info("Processing complexity report ");

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -25,7 +25,6 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.Settings;
 import org.sonar.api.measures.Measure;
-import org.sonar.api.resources.Project;
 import org.sonar.plugins.objectivec.ObjectiveCPlugin;
 import org.sonar.plugins.objectivec.core.ObjectiveC;
 
@@ -60,14 +59,13 @@ public class LizardSensor implements Sensor {
 
     /**
      *
-     * @param project
      * @param sensorContext
      */
-    private void analyse(Project project, SensorContext sensorContext) {
+    private void analyse(SensorContext sensorContext) {
         final String projectBaseDir = fileSystem.baseDir().getPath();
         Map<String, List<Measure>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
         LOGGER.info("Saving results of complexity analysis");
-        new LizardMeasurePersistor(project, sensorContext, fileSystem).saveMeasures(measures);
+        new LizardMeasurePersistor(sensorContext, fileSystem).saveMeasures(measures);
     }
 
     /**
@@ -103,6 +101,6 @@ public class LizardSensor implements Sensor {
 
     @Override
     public void execute(@Nonnull org.sonar.api.batch.sensor.SensorContext context) {
-        analyse(null, (SensorContext) context);
+        analyse((SensorContext) context);
     }
 }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -19,15 +19,17 @@ package org.sonar.plugins.objectivec.complexity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.Sensor;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.Settings;
 import org.sonar.api.measures.Measure;
 import org.sonar.api.resources.Project;
 import org.sonar.plugins.objectivec.ObjectiveCPlugin;
 import org.sonar.plugins.objectivec.core.ObjectiveC;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,8 @@ import java.util.Map;
 public class LizardSensor implements Sensor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LizardSensor.class);
+
+    private static final String NAME = "Lizard complexity sensor";
 
     public static final String REPORT_PATH_KEY = ObjectiveCPlugin.PROPERTY_PREFIX + ".lizard.report";
     public static final String DEFAULT_REPORT_PATH = "sonar-reports/lizard-report.xml";
@@ -98,5 +102,16 @@ public class LizardSensor implements Sensor {
             reportPath = DEFAULT_REPORT_PATH;
         }
         return reportPath;
+    }
+
+    @Override
+    public void describe(@Nonnull SensorDescriptor descriptor) {
+        descriptor.name(NAME);
+        descriptor.onlyOnLanguage(ObjectiveC.KEY);
+    }
+
+    @Override
+    public void execute(@Nonnull org.sonar.api.batch.sensor.SensorContext context) {
+        analyse(null, (SensorContext) context);
     }
 }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -58,6 +58,17 @@ public class LizardSensor implements Sensor {
         this.fileSystem = moduleFileSystem;
     }
 
+    @Override
+    public void describe(@Nonnull SensorDescriptor descriptor) {
+        descriptor.name(NAME);
+        descriptor.onlyOnLanguage(ObjectiveC.KEY);
+    }
+
+    @Override
+    public void execute(@Nonnull SensorContext context) {
+        analyse(context);
+    }
+
     /**
      *
      * @param sensorContext
@@ -105,16 +116,5 @@ public class LizardSensor implements Sensor {
         }
 
         return String.format("%s/%s",basePath, reportPath);
-    }
-
-    @Override
-    public void describe(@Nonnull SensorDescriptor descriptor) {
-        descriptor.name(NAME);
-        descriptor.onlyOnLanguage(ObjectiveC.KEY);
-    }
-
-    @Override
-    public void execute(@Nonnull SensorContext context) {
-        analyse(context);
     }
 }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -50,6 +50,8 @@ public class LizardSensor implements Sensor {
     public static final String REPORT_PATH_KEY = ObjectiveCPlugin.PROPERTY_PREFIX + ".lizard.report";
     public static final String DEFAULT_REPORT_PATH = "sonar-reports/lizard-report.xml";
 
+    private final LizardReportParser parser = new LizardReportParser();
+
     private final Settings conf;
     private final FileSystem fileSystem;
 
@@ -67,7 +69,7 @@ public class LizardSensor implements Sensor {
     @Override
     public void execute(@Nonnull SensorContext context) {
         final String projectBaseDir = fileSystem.baseDir().getPath();
-        Map<String, List<LizardMeasure<Integer>>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
+        Map<String, List<LizardMeasure<Integer>>> measures = parseReportsIn(projectBaseDir, parser);
         if (measures.isEmpty()) {
             return;
         }

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -61,15 +61,6 @@ public class LizardSensor implements Sensor {
     /**
      *
      * @param project
-     * @return true if the project is root the root project and uses Objective-C
-     */
-    public boolean shouldExecuteOnProject(Project project) {
-        return project.isRoot() && fileSystem.languages().contains(ObjectiveC.KEY);
-    }
-
-    /**
-     *
-     * @param project
      * @param sensorContext
      */
     public void analyse(Project project, SensorContext sensorContext) {

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -63,7 +63,7 @@ public class LizardSensor implements Sensor {
      * @param project
      * @param sensorContext
      */
-    public void analyse(Project project, SensorContext sensorContext) {
+    private void analyse(Project project, SensorContext sensorContext) {
         final String projectBaseDir = fileSystem.baseDir().getPath();
         Map<String, List<Measure>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
         LOGGER.info("Saving results of complexity analysis");

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -66,14 +66,6 @@ public class LizardSensor implements Sensor {
 
     @Override
     public void execute(@Nonnull SensorContext context) {
-        analyse(context);
-    }
-
-    /**
-     *
-     * @param sensorContext
-     */
-    private void analyse(SensorContext sensorContext) {
         final String projectBaseDir = fileSystem.baseDir().getPath();
         Map<String, List<LizardMeasure<Integer>>> measures = parseReportsIn(projectBaseDir, new LizardReportParser());
         if (measures.isEmpty()) {
@@ -81,7 +73,8 @@ public class LizardSensor implements Sensor {
         }
 
         LOGGER.info("Saving results of complexity analysis");
-        new LizardMeasurePersistor(sensorContext, fileSystem).saveMeasures(measures);
+        new LizardMeasurePersistor(context, fileSystem)
+                .saveMeasures(measures);
     }
 
     /**

--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/complexity/LizardSensor.java
@@ -75,22 +75,26 @@ public class LizardSensor implements Sensor {
      * @return Map containing as key the name of the file and as value a list containing the measures for that file
      */
     private <T extends Serializable> Map<String, List<LizardMeasure<T>>> parseReportsIn(final String baseDir, LizardReportParser parser) {
-        final StringBuilder reportFileName = new StringBuilder(baseDir);
-        reportFileName.append("/").append(reportPath());
+        final String reportFileName = buildReportPath(baseDir);
+
         LOGGER.info("Processing complexity report ");
-        return parser.parseReport(new File(reportFileName.toString()));
+        return parser.parseReport(new File(reportFileName));
     }
 
     /**
-     *
+     * Build path for the report file using the {@code basePath} as prefix
+     * @param basePath Base path for the project.
      * @return the default report path or the one specified in the sonar-project.properties
      */
-    private String reportPath() {
+    String buildReportPath(String basePath) {
         String reportPath = conf.getString(REPORT_PATH_KEY);
+
         if (reportPath == null) {
+            LOGGER.debug("No value specified for \"" + REPORT_PATH_KEY + "\" using default path");
             reportPath = DEFAULT_REPORT_PATH;
         }
-        return reportPath;
+
+        return String.format("%s/%s",basePath, reportPath);
     }
 
     @Override

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -183,7 +183,7 @@ public class LizardReportParserTest {
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
         List<Measure> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
-        Assert.assertEquals(3, list2.size());
+        Assert.assertEquals(2, list2.size());
         for (Measure measure : list2) {
             String s = measure.getMetric().getKey();
 

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -35,7 +35,6 @@ package org.sonar.plugins.objectivec.complexity;/*
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +47,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Andres Gil Herrera
@@ -156,37 +157,37 @@ public class LizardReportParserTest {
     public void parseReportShouldReturnMapWhenXMLFileIsCorrect() {
         LizardReportParser parser = new LizardReportParser();
 
-        Assert.assertNotNull("correct file is null", correctFile);
+        assertNotNull("correct file is null", correctFile);
 
         Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(correctFile);
 
-        Assert.assertFalse("report is empty", report.isEmpty());
+        assertFalse("report is empty", report.isEmpty());
 
-        Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.h"));
+        assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.h"));
         List<LizardMeasure<Integer>> list1 = report.get("App/Controller/Accelerate/AccelerationViewController.h");
-        Assert.assertEquals(2, list1.size());
+        assertEquals(2, list1.size());
 
         for (LizardMeasure measure : list1) {
             String s = measure.getMetric().key();
 
             if (s.equals(CoreMetrics.FUNCTIONS_KEY)) {
-                Assert.assertEquals("Header Functions has a wrong value", 0, measure.getValue());
+                assertEquals("Header Functions has a wrong value", 0, measure.getValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
-                Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getValue());
+                assertEquals("Header Complexity has a wrong value", 0, measure.getValue());
             }
         }
 
-        Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
+        assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
         List<LizardMeasure<Integer>> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
-        Assert.assertEquals(2, list2.size());
+        assertEquals(2, list2.size());
         for (LizardMeasure measure : list2) {
             String s = measure.getMetric().key();
 
             if (s.equals(CoreMetrics.FUNCTIONS_KEY)) {
-                Assert.assertEquals("MFile Functions has a wrong value", 2, measure.getValue());
+                assertEquals("MFile Functions has a wrong value", 2, measure.getValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
-                Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getValue());
+                assertEquals("MFile Complexity has a wrong value", 6, measure.getValue());
             }
         }
     }
@@ -198,10 +199,10 @@ public class LizardReportParserTest {
     public void parseReportShouldReturnNullWhenXMLFileIsIncorrect() {
         LizardReportParser parser = new LizardReportParser();
 
-        Assert.assertNotNull("correct file is null", incorrectFile);
+        assertNotNull("correct file is null", incorrectFile);
 
         Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(incorrectFile);
-        Assert.assertTrue("report is not empty", report.isEmpty());
+        assertTrue("report is not empty", report.isEmpty());
 
     }
 

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -168,7 +168,7 @@ public class LizardReportParserTest {
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.h"));
         List<Measure> list1 = report.get("App/Controller/Accelerate/AccelerationViewController.h");
-        Assert.assertEquals(4, list1.size());
+        Assert.assertEquals(2, list1.size());
 
         for (Measure measure : list1) {
             String s = measure.getMetric().getKey();
@@ -177,15 +177,13 @@ public class LizardReportParserTest {
                 Assert.assertEquals("Header Functions has a wrong value", 0, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
                 Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getIntValue().intValue());
-            } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
-                Assert.assertEquals("Header File Complexity has a wrong value", 0.0d, measure.getValue().doubleValue(), 0.0d);
             }
         }
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
         List<Measure> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
-        Assert.assertEquals(5, list2.size());
+        Assert.assertEquals(3, list2.size());
         for (Measure measure : list2) {
             String s = measure.getMetric().getKey();
 
@@ -193,8 +191,6 @@ public class LizardReportParserTest {
                 Assert.assertEquals("MFile Functions has a wrong value", 2, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
                 Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getIntValue().intValue());
-            } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
-                Assert.assertEquals("MFile File Complexity has a wrong value", 6.0d, measure.getValue().doubleValue(), 0.0d);
             }
         }
     }

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -41,8 +41,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.measures.Measure;
-import org.sonar.plugins.objectivec.complexity.LizardReportParser;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -50,8 +48,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Andres Gil Herrera
@@ -162,35 +158,35 @@ public class LizardReportParserTest {
 
         Assert.assertNotNull("correct file is null", correctFile);
 
-        Map<String, List<Measure>> report = parser.parseReport(correctFile);
+        Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(correctFile);
 
         Assert.assertNotNull("report is null", report);
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.h"));
-        List<Measure> list1 = report.get("App/Controller/Accelerate/AccelerationViewController.h");
+        List<LizardMeasure<Integer>> list1 = report.get("App/Controller/Accelerate/AccelerationViewController.h");
         Assert.assertEquals(2, list1.size());
 
-        for (Measure measure : list1) {
-            String s = measure.getMetric().getKey();
+        for (LizardMeasure measure : list1) {
+            String s = measure.getMetric().key();
 
             if (s.equals(CoreMetrics.FUNCTIONS_KEY)) {
-                Assert.assertEquals("Header Functions has a wrong value", 0, measure.getIntValue().intValue());
+                Assert.assertEquals("Header Functions has a wrong value", 0, measure.getValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
-                Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getIntValue().intValue());
+                Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getValue());
             }
         }
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
-        List<Measure> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
+        List<LizardMeasure<Integer>> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
         Assert.assertEquals(2, list2.size());
-        for (Measure measure : list2) {
-            String s = measure.getMetric().getKey();
+        for (LizardMeasure measure : list2) {
+            String s = measure.getMetric().key();
 
             if (s.equals(CoreMetrics.FUNCTIONS_KEY)) {
-                Assert.assertEquals("MFile Functions has a wrong value", 2, measure.getIntValue().intValue());
+                Assert.assertEquals("MFile Functions has a wrong value", 2, measure.getValue());
             } else if (s.equals(CoreMetrics.COMPLEXITY_KEY)) {
-                Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getIntValue().intValue());
+                Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getValue());
             }
         }
     }
@@ -204,7 +200,7 @@ public class LizardReportParserTest {
 
         Assert.assertNotNull("correct file is null", incorrectFile);
 
-        Map<String, List<Measure>> report = parser.parseReport(incorrectFile);
+        Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(incorrectFile);
         Assert.assertNull("report is not null", report);
 
     }

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -160,7 +160,7 @@ public class LizardReportParserTest {
 
         Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(correctFile);
 
-        Assert.assertNotNull("report is null", report);
+        Assert.assertFalse("report is empty", report.isEmpty());
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.h"));
         List<LizardMeasure<Integer>> list1 = report.get("App/Controller/Accelerate/AccelerationViewController.h");
@@ -201,7 +201,7 @@ public class LizardReportParserTest {
         Assert.assertNotNull("correct file is null", incorrectFile);
 
         Map<String, List<LizardMeasure<Integer>>> report = parser.parseReport(incorrectFile);
-        Assert.assertNull("report is not null", report);
+        Assert.assertTrue("report is not empty", report.isEmpty());
 
     }
 

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -179,8 +179,6 @@ public class LizardReportParserTest {
                 Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
                 Assert.assertEquals("Header File Complexity has a wrong value", 0.0d, measure.getValue().doubleValue(), 0.0d);
-            } else if (s.equals(CoreMetrics.COMPLEXITY_IN_FUNCTIONS_KEY)) {
-                Assert.assertEquals("Header Complexity in Functions has a wrong value", 0, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FUNCTION_COMPLEXITY_KEY)) {
                 Assert.assertEquals("Header Functions Complexity has a wrong value", 0.0d, measure.getValue().doubleValue(), 0.0d);
             }
@@ -189,7 +187,7 @@ public class LizardReportParserTest {
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
         List<Measure> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
-        Assert.assertEquals(7, list2.size());
+        Assert.assertEquals(6, list2.size());
         for (Measure measure : list2) {
             String s = measure.getMetric().getKey();
 
@@ -199,8 +197,6 @@ public class LizardReportParserTest {
                 Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
                 Assert.assertEquals("MFile File Complexity has a wrong value", 6.0d, measure.getValue().doubleValue(), 0.0d);
-            } else if (s.equals(CoreMetrics.COMPLEXITY_IN_FUNCTIONS_KEY)) {
-                Assert.assertEquals("MFile Complexity in Functions has a wrong value", 6, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FUNCTION_COMPLEXITY_KEY)) {
                 Assert.assertEquals("MFile Functions Complexity has a wrong value", 3.0d, measure.getValue().doubleValue(), 0.0d);
             }

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardReportParserTest.java
@@ -179,15 +179,13 @@ public class LizardReportParserTest {
                 Assert.assertEquals("Header Complexity has a wrong value", 0, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
                 Assert.assertEquals("Header File Complexity has a wrong value", 0.0d, measure.getValue().doubleValue(), 0.0d);
-            } else if (s.equals(CoreMetrics.FUNCTION_COMPLEXITY_KEY)) {
-                Assert.assertEquals("Header Functions Complexity has a wrong value", 0.0d, measure.getValue().doubleValue(), 0.0d);
             }
         }
 
         Assert.assertTrue("Key is not there", report.containsKey("App/Controller/Accelerate/AccelerationViewController.m"));
 
         List<Measure> list2 = report.get("App/Controller/Accelerate/AccelerationViewController.m");
-        Assert.assertEquals(6, list2.size());
+        Assert.assertEquals(5, list2.size());
         for (Measure measure : list2) {
             String s = measure.getMetric().getKey();
 
@@ -197,8 +195,6 @@ public class LizardReportParserTest {
                 Assert.assertEquals("MFile Complexity has a wrong value", 6, measure.getIntValue().intValue());
             } else if (s.equals(CoreMetrics.FILE_COMPLEXITY_KEY)) {
                 Assert.assertEquals("MFile File Complexity has a wrong value", 6.0d, measure.getValue().doubleValue(), 0.0d);
-            } else if (s.equals(CoreMetrics.FUNCTION_COMPLEXITY_KEY)) {
-                Assert.assertEquals("MFile Functions Complexity has a wrong value", 3.0d, measure.getValue().doubleValue(), 0.0d);
             }
         }
     }

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
@@ -35,19 +35,22 @@ import org.sonar.plugins.objectivec.core.ObjectiveC;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(JUnit4.class)
 public class LizardSensorTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private Sensor sensor;
+    private Settings settings;
+    private LizardSensor sensor;
 
     @Before
     public void prepare() throws IOException {
         File baseDirectory = temporaryFolder.newFolder();
 
         DefaultFileSystem fileSystem = new DefaultFileSystem(baseDirectory.toPath());
-        Settings settings = new MapSettings();
+        settings = new MapSettings();
 
         sensor = new LizardSensor(fileSystem, settings);
     }
@@ -60,5 +63,27 @@ public class LizardSensorTest {
 
         Assert.assertEquals("Lizard complexity sensor", descriptor.name());
         Assert.assertTrue(descriptor.languages().contains(ObjectiveC.KEY));
+    }
+
+    @Test
+    public void buildReportPath_withoutConfiguredReportPath() {
+        String basePath = temporaryFolder.getRoot().getPath();
+        String expected = String.format("%s/%s", basePath, LizardSensor.DEFAULT_REPORT_PATH);
+
+        String actual = sensor.buildReportPath(basePath);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void buildReportPath_withConfiguredReportPath() {
+        String basePath = temporaryFolder.getRoot().getPath();
+        String path = "lizard-report.xml";
+        String expected = String.format("%s/%s", basePath, path);
+        settings.setProperty(LizardSensor.REPORT_PATH_KEY, path);
+
+        String actual = sensor.buildReportPath(basePath);
+
+        assertEquals(expected, actual);
     }
 }

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
@@ -1,0 +1,64 @@
+/**
+ * backelite-sonar-objective-c-plugin - Enables analysis of Objective-C projects into SonarQube.
+ * Copyright © 2012 OCTO Technology, Backelite (${email})
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sonar.plugins.objectivec.complexity;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.config.MapSettings;
+import org.sonar.api.config.Settings;
+import org.sonar.plugins.objectivec.core.ObjectiveC;
+
+import java.io.File;
+import java.io.IOException;
+
+@RunWith(JUnit4.class)
+public class LizardSensorTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Sensor sensor;
+
+    @Before
+    public void prepare() throws IOException {
+        File baseDirectory = temporaryFolder.newFolder();
+
+        DefaultFileSystem fileSystem = new DefaultFileSystem(baseDirectory.toPath());
+        Settings settings = new MapSettings();
+
+        sensor = new LizardSensor(fileSystem, settings);
+    }
+
+    @Test
+    public void describe() {
+        DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
+
+        sensor.describe(descriptor);
+
+        Assert.assertEquals("Lizard complexity sensor", descriptor.name());
+        Assert.assertTrue(descriptor.languages().contains(ObjectiveC.KEY));
+    }
+}

--- a/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
+++ b/sonar-objective-c-plugin/src/test/java/org/sonar/plugins/objectivec/complexity/LizardSensorTest.java
@@ -17,7 +17,6 @@
  */
 package org.sonar.plugins.objectivec.complexity;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,8 +24,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.sensor.Sensor;
-import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.config.MapSettings;
 import org.sonar.api.config.Settings;
@@ -36,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class LizardSensorTest {
@@ -61,8 +59,8 @@ public class LizardSensorTest {
 
         sensor.describe(descriptor);
 
-        Assert.assertEquals("Lizard complexity sensor", descriptor.name());
-        Assert.assertTrue(descriptor.languages().contains(ObjectiveC.KEY));
+        assertEquals("Lizard complexity sensor", descriptor.name());
+        assertTrue(descriptor.languages().contains(ObjectiveC.KEY));
     }
 
     @Test


### PR DESCRIPTION
Changes within this pull request improve the parsing of Lizard complexity reports:

- Ensure compatibility with SonarQube 7.0 by removing use of methods that have been removed from the scanner on the server side (solves #56).
- Remove use of deprecated metrics (solves #54).
- Reduce technical dept by improving readability, annotating methods with their null-ability, use updated API:s and reduce usage of deprecated classes.
- Warn instead of throwing an exception when the lizard report XML file is not available.