### PR TITLE
FIX - crash on getTimeAttributeInMS method when value is null

### DIFF
--- a/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/surefire/data/SurefireStaxHandler.java
+++ b/sonar-objective-c-plugin/src/main/java/org/sonar/plugins/objectivec/surefire/data/SurefireStaxHandler.java
@@ -120,6 +120,9 @@ public class SurefireStaxHandler implements XmlStreamHandler {
 
     private static long getTimeAttributeInMS(String value) throws XMLStreamException {
         // hardcoded to Locale.ENGLISH see http://jira.codehaus.org/browse/SONAR-602
+        if (value == null) {
+            value = "0";
+        }
         try {
             Double time = ParsingUtils.parseNumber(value, Locale.ENGLISH);
             return !Double.isNaN(time) ? (long) ParsingUtils.scaleValue(time * 1000, 3) : 0L;


### PR DESCRIPTION
This should fix an error during SonarQube Scanner execution occurred in getTimeAttributeInMS. The error occurred when value is null and it's passed to ParsingUtils.parseNumber() which according to [the documentation](http://javadocs.sonarsource.org/6.7/apidocs/org/sonar/api/utils/ParsingUtils.html#parseNumber-java.lang.String-java.util.Locale-), the latter will throw an exception.